### PR TITLE
JL upcoming events

### DIFF
--- a/assets/global-classes.less
+++ b/assets/global-classes.less
@@ -35,7 +35,7 @@
   grid-template-areas: "img content userbtns"
                        "X admin admin";
   grid-template-columns: 1fr 4fr 1fr;
-  grid-template-rows: 3fr 1fr;
+  grid-template-rows: 2fr 1fr;
   margin-bottom: 2em;
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,5 +46,7 @@ html {
   width: 100%;
   height: 100vh;
   background-color: var(--body-color);
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/src/components/Events/Event.vue
+++ b/src/components/Events/Event.vue
@@ -10,17 +10,29 @@
           </div>
       </div>
        <div class="event-btns--user">
-        <access-control :roles="['user']" role="user">
+        <access-control :roles="['user']" :role="currentRole">
           <slot name="btn1" :event="event" />
           <slot name="btn2" :event="event" />
         </access-control>
       </div>
       <div class="event-btns--admin_container">
-        <access-control :roles="['admin']" role="currentRole"
+        <access-control :roles="['admin']" :role="currentRole"
         :_class="['event-btns--admin_wrapper']">
-          <button class="event-btn">Edit</button>
-          <button class="event-btn">Announce</button>
-          <button class="event-btn">Check RSVP</button>
+          <router-link
+            :to="{ name: 'create-event', params: { eventId: event.id}}"
+            class="event-btn" tag="button">
+            Edit
+          </router-link>
+          <button
+            v-on:click="announce({event: event})"
+            class="event-btn">
+            Announce
+          </button>
+          <button
+            v-on:click="viewRSVP({event: event})"
+            class="event-btn">
+            View RSVP
+          </button>
         </access-control>
       </div>
   </div>
@@ -39,8 +51,16 @@ export default {
       type: Object,
       required: true,
     },
-    currentRole: {
-      type: String,
+    currentRole: String,
+  },
+  methods: {
+    announce(payload) {
+      // eslint-disable-next-line no-alert
+      alert(`Once created, link create-announcement component here for ${payload.event.name}.`);
+    },
+    viewRSVP(payload) {
+      // eslint-disable-next-line no-alert
+      alert(`The users registered for ${payload.event.name} are ${payload.event.users}.`);
     },
   },
 };

--- a/src/components/Events/Event.vue
+++ b/src/components/Events/Event.vue
@@ -16,7 +16,8 @@
         </access-control>
       </div>
       <div class="event-btns--admin_container">
-        <access-control :roles="['admin']" role="" :_class="['event-btns--admin_wrapper']">
+        <access-control :roles="['admin']" role="currentRole"
+        :_class="['event-btns--admin_wrapper']">
           <button class="event-btn">Edit</button>
           <button class="event-btn">Announce</button>
           <button class="event-btn">Check RSVP</button>
@@ -37,6 +38,9 @@ export default {
     event: {
       type: Object,
       required: true,
+    },
+    currentRole: {
+      type: String,
     },
   },
 };

--- a/src/components/Events/EventsList.vue
+++ b/src/components/Events/EventsList.vue
@@ -12,7 +12,7 @@
             v-on:click='incrementCurrentPage'>Next</button>
         </div>
         <div v-if="events.length > 0" class="events-container">
-          <event v-for="event in pageOfEvents" :key="event.id" :event="event">
+          <event v-for="event in pageOfEvents" :key="event.id" :event="event" :role="currentRole">
             <template v-slot:btn1="slotProps">
               <slot name="eventBtn1" :event="slotProps.event"/>
             </template>
@@ -42,6 +42,9 @@ export default {
     events: {
       type: Array,
       required: true,
+    },
+    currentRole: {
+      type: String,
     },
   },
   computed: {

--- a/src/components/Events/EventsList.vue
+++ b/src/components/Events/EventsList.vue
@@ -12,7 +12,8 @@
             v-on:click='incrementCurrentPage'>Next</button>
         </div>
         <div v-if="events.length > 0" class="events-container">
-          <event v-for="event in pageOfEvents" :key="event.id" :event="event" :role="currentRole">
+          <event v-for="event in pageOfEvents" :key="event.id" :event="event"
+          :currentRole="currentRole">
             <template v-slot:btn1="slotProps">
               <slot name="eventBtn1" :event="slotProps.event"/>
             </template>
@@ -43,9 +44,7 @@ export default {
       type: Array,
       required: true,
     },
-    currentRole: {
-      type: String,
-    },
+    currentRole: String,
   },
   computed: {
     // list of a single page's worth of items

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -12,6 +12,7 @@ import MyEventsView from '../views/MyEventsView.vue';
 import CheckoutView from '../views/CheckoutView.vue';
 import SingleEventView from '../views/SingleEventView.vue';
 import CreateEventView from '../views/CreateEventView.vue';
+import UpcomingEventsView from '../views/UpcomingEventsView.vue';
 
 Vue.use(Router);
 
@@ -37,6 +38,11 @@ export default new Router({
       path: '/create-event',
       name: 'create-event',
       component: CreateEventView,
+    },
+    {
+      path: '/upcoming-events',
+      name: 'upcoming-events',
+      component: UpcomingEventsView,
     },
     {
       path: '/event/:eventId',

--- a/src/views/CreateEventView.vue
+++ b/src/views/CreateEventView.vue
@@ -87,7 +87,7 @@ export default {
 <style scoped>
 @import '../../assets/color-constants.less';
 .container {
-    margin: 3rem;
+    margin: 1rem;
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/src/views/EventsView.vue
+++ b/src/views/EventsView.vue
@@ -1,5 +1,5 @@
 <template>
-  <events-list :events="allEvents">
+  <events-list :events="allEvents" currentRole="user">
     <template v-slot:noEventsMsg>
       <h3>Sorry, there are no currently availible events!</h3>
     </template>

--- a/src/views/UpcomingEventsView.vue
+++ b/src/views/UpcomingEventsView.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-import { mapState, mapMutations } from 'vuex';
+import { mapState } from 'vuex';
 import EventsList from '../components/Events/EventsList.vue';
 
 export default {
@@ -23,9 +23,6 @@ export default {
     }),
   },
   methods: {
-    ...mapMutations('cart', {
-      registerForEvent: 'registerForEvent',
-    }),
     announce(payload) {
       // eslint-disable-next-line no-alert
       alert(`Once created, link create-announcement component here for ${payload.event.name}.`);

--- a/src/views/UpcomingEventsView.vue
+++ b/src/views/UpcomingEventsView.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-  <events-list :events="allEvents" :currentRole="role">
+  <events-list :events="allEvents" currentRole="admin">
     <template v-slot:noEventsMsg>
       <h3>Sorry, there are no currently availible events!</h3>
     </template>
@@ -14,11 +14,6 @@ import EventsList from '../components/Events/EventsList.vue';
 
 export default {
   name: 'UpcomingEventsView',
-  data() {
-    return {
-      role: 'admin',
-    };
-  },
   components: {
     EventsList,
   },

--- a/src/views/UpcomingEventsView.vue
+++ b/src/views/UpcomingEventsView.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+  <events-list :events="allEvents" :currentRole="role">
+    <template v-slot:noEventsMsg>
+      <h3>Sorry, there are no currently availible events!</h3>
+    </template>
+  </events-list>
+  </div>
+</template>
+
+<script>
+import { mapState, mapMutations } from 'vuex';
+import EventsList from '../components/Events/EventsList.vue';
+
+export default {
+  name: 'UpcomingEventsView',
+  data() {
+    return {
+      role: 'admin',
+    };
+  },
+  components: {
+    EventsList,
+  },
+  computed: {
+    ...mapState('events', {
+      allEvents: 'events',
+    }),
+  },
+  methods: {
+    ...mapMutations('cart', {
+      registerForEvent: 'registerForEvent',
+    }),
+    announce(payload) {
+      // eslint-disable-next-line no-alert
+      alert(`Once created, link create-announcement component here for ${payload.event.name}.`);
+    },
+    viewRSVP(payload) {
+      // eslint-disable-next-line no-alert
+      alert(`The users registered for ${payload.event.name} are ${payload.event.users}.`);
+    },
+  },
+};
+</script>
+
+<style lang="less" scoped>
+@import '../../assets/global-classes.less';
+</style>


### PR DESCRIPTION
<img width="1442" alt="Screen Shot 2020-04-24 at 1 53 29 PM" src="https://user-images.githubusercontent.com/55663537/80256457-976a4680-8633-11ea-836e-0079c20263e4.png">
<img width="1440" alt="Screen Shot 2020-04-24 at 1 53 51 PM" src="https://user-images.githubusercontent.com/55663537/80256462-989b7380-8633-11ea-9f72-90c272854546.png">
<img width="1943" alt="Screen Shot 2020-04-24 at 1 54 38 PM" src="https://user-images.githubusercontent.com/55663537/80256464-9a653700-8633-11ea-8f5b-308611442d5a.png">

Hooked up the two different upcoming events views to match figma sitemap – the default user view to register or view single event, and admin view to edit, announce, and check RSVPs.  The admin upcoming-events view will be linked from the admin profile page once that is created.

Current placeholders for admin buttons:
- edit currently links to create event page (next steps are auto-populating this page to pass event info)
- announce method can be hooked up once that component has been created
- view RSVP currently gives a pop-up with the users that are registered for that event
