### PR TITLE
Styling changes to event lists on upcoming and mine

### DIFF
--- a/assets/global-classes.less
+++ b/assets/global-classes.less
@@ -128,7 +128,6 @@ h1 {
 .event-btn {
   width: 12rem;
   display: inline-block;
-  margin-bottom: 1em;
   background-color: @button-bg;
   color: @button-color;
   border: none;

--- a/src/components/Events/Event.vue
+++ b/src/components/Events/Event.vue
@@ -1,60 +1,28 @@
 <template>
-  <div class="event__container">
+  <div class="event-container">
       <div class="event-img">
+        <div class="img-box">
           <img :src="event.thumbnail" />
+          <span class="start-date">{{ toStringDate(event.details.start) }}</span>
+        </div>
       </div>
       <div class="event-content">
           <div class="content-wrapper">
-              <h3>{{ event.title }}</h3>
-              <p>{{ event.details.description }}</p>
+              <p class="event-title">{{ event.title }}</p>
+              <p class="event-body">{{ event.details.description }}</p>
           </div>
       </div>
-       <div class="event-btns--user">
-        <access-control :roles="[USER[ROLE.GP], USER[ROLE.PF], USER[ROLE.ADMIN]]">
-          <slot name="btn1" :event="event" />
-          <slot name="btn2" :event="event" />
-        </access-control>
-      </div>
-      <div class="event-btns--admin_container">
-        <access-control :roles="[USER[ROLE.ADMIN]]"
-        :_class="['event-btns--admin_wrapper']">
-          <router-link
-            :to="{ name: 'edit-event', params: { eventId: event.id}}"
-            class="event-btn" tag="button">
-            Edit
-          </router-link>
-          <router-link
-            :to="{ name: 'create-announcement', params: { eventName: event.name}}"
-            class="event-btn" tag="button">
-            Announce
-          </router-link>
-          <button
-            v-on:click="viewRSVP({event: event})"
-            class="event-btn">
-            View RSVP
-          </button>
-        </access-control>
+       <div class="event-btns">
+         <slot name="btns" :event="event"/>
       </div>
   </div>
 </template>
 
 <script>
-import AccessControl from '../AccessControl/AccessControl.vue';
-import {
-  USER, ROLE,
-} from '../../utils/constants/user';
+import DateUtils from '../../utils/DateUtils';
 
 export default {
   name: 'Event',
-  components: {
-    AccessControl,
-  },
-  data() {
-    return {
-      USER,
-      ROLE,
-    };
-  },
   props: {
     event: {
       type: Object,
@@ -62,18 +30,88 @@ export default {
     },
   },
   methods: {
-    announce(payload) {
-      // eslint-disable-next-line no-alert
-      alert(`Once created, link create-announcement component here for ${payload.event.title}.`);
-    },
     viewRSVP(payload) {
+      // TODO: Move to single event view
       // eslint-disable-next-line no-alert
       alert(`The users registered for ${payload.event.title} are ${payload.event.users}.`);
+    },
+    toStringDate(date) {
+      return DateUtils.toStringDate(date);
     },
   },
 };
 </script>
 
 <style lang="less">
-    @import '../../../assets/global-classes.less';
+  @import '../../../assets/global-classes.less';
+
+  .event-container {
+    display: grid;
+    grid-template-columns: 2fr 8fr 1fr;
+    grid-template-rows: 1fr;
+    grid-template-areas: "img content actions";
+
+    height: 150px;
+  }
+
+  .event-img {
+    grid-area: img;
+  }
+  .img-box {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background-color: #E5E5E5;
+    border-radius: 4px;
+  }
+  .start-date {
+    font-family: Raleway;
+    font-weight: lighter;
+    font-size: 1.3rem;
+    color: white;
+
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+  }
+
+
+  .event-content {
+    grid-area: content;
+    position: relative;
+    overflow: hidden;
+    font-family: Raleway;
+    padding-right: 8px;
+  }
+  .event-content:after {
+    content:"";
+    top:0;
+    left:0;
+    position: absolute;
+    width:100%;
+    height:100%;
+    background: linear-gradient(transparent 90px, white);
+  }
+
+  .event-title {
+    font-size: 1.4rem;
+    font-weight: bold;
+  }
+
+
+  .event-btns {
+    grid-area: actions;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    align-items: flex-end;
+  }
+
+  /* TODO: Do this without !important tag */
+  button {
+    padding-bottom: 4px !important;
+    padding-top: 4px !important;
+  }
 </style>

--- a/src/components/Events/EventsList.vue
+++ b/src/components/Events/EventsList.vue
@@ -1,26 +1,35 @@
 <template>
     <div>
-        <slot name="header"></slot>
-        <slot v-if="events.length === 0" name="NoEventsMsg"></slot>
-        <div v-else class='pagination-wrapper'>
-          <button
-            class='pagination__btn'
-            v-on:click='decrementCurrentPage'>Prev</button>
-          <span><b>Page {{ currentPage + 1 }} of {{ maxPage + 1 }}</b></span>
-          <button
-            class='pagination__btn'
-            v-on:click='incrementCurrentPage'>Next</button>
+      <slot name="header"></slot>
+      <slot v-if="events.length === 0" name="NoEventsMsg"></slot>
+      <div v-else class="events-container">
+        <event v-for="event in pageOfEvents" :key="event.id" :event="event">
+          <!-- Note that event buttons passed should be wrapped in an access control
+            or a div when being passed to get the desired flex styling -->
+          <template v-slot:btns="slotProps">
+            <slot name="eventBtns" :event="slotProps.event" />
+          </template>
+        </event>
+        <div class='pagination-wrapper'>
+          <div>
+            <div
+                v-if="!firstPage"
+                class='btn--tertiary pagination__btn'
+                v-on:click='decrementCurrentPage'>
+              Previous Page
+            </div>
+          </div>
+          <span>{{ currentPage + 1 }} of {{ maxPage }}</span>
+          <div>
+            <div
+                v-if="!lastPage"
+                class='btn--tertiary pagination__btn'
+                v-on:click='incrementCurrentPage'>
+              Next Page
+            </div>
+          </div>
         </div>
-        <div v-if="events.length > 0" class="events-container">
-          <event v-for="event in pageOfEvents" :key="event.id" :event="event">
-            <template v-slot:btn1="slotProps">
-              <slot name="eventBtn1" :event="slotProps.event"/>
-            </template>
-            <template v-slot:btn2="slotProps">
-              <slot name="eventBtn2" :event="slotProps.event"/>
-            </template>
-          </event>
-        </div>
+      </div>
     </div>
 </template>
 
@@ -34,7 +43,7 @@ export default {
   },
   data() {
     return {
-      eventsPerPage: 5,
+      eventsPerPage: 20,
       currentPage: 0,
     };
   },
@@ -55,7 +64,13 @@ export default {
     },
     // page number of the last page
     maxPage() {
-      return Math.floor(this.events.length / this.eventsPerPage);
+      return Math.ceil(this.events.length / this.eventsPerPage);
+    },
+    firstPage() {
+      return this.currentPage === 0;
+    },
+    lastPage() {
+      return this.currentPage === this.maxPage - 1;
     },
   },
   methods: {
@@ -81,23 +96,20 @@ export default {
     margin: 0 auto;
   }
 
-  .pagination-wrapper {
-    display: flex;
-    justify-content: center;
+  .events-container > div {
+    margin: 5px 0;
   }
 
-  .pagination-wrapper span {
-    display: block;
+  .pagination-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
   }
 
   .pagination__btn {
-    margin-left: 1rem;
-    margin-right: 1rem;
-    background-color: @button-bg;
-    color: @button-color;
-    padding: 1em 3em 1em 3em;
-    border-radius: 4px;
-    border: none;
+    margin: 0;
+    padding: 6px 3px;
+    border-radius: 6px;
     cursor: pointer;
   }
 </style>

--- a/src/components/Events/EventsListScroll.vue
+++ b/src/components/Events/EventsListScroll.vue
@@ -3,11 +3,8 @@
     <slot v-if="events.length === 0" name="NoEventsMsg"></slot>
     <div v-else>
       <event v-for="event in events" :key="event.id" :event="event" >
-        <template v-slot:btn1="slotProps">
-          <slot name="eventBtn1" :event="slotProps.event" />
-        </template>
-        <template v-slot:btn2="slotProps">
-          <slot name="eventBtn2" :event="slotProps.event"/>
+        <template v-slot:btns="slotProps">
+          <slot name="eventBtns" :event="slotProps.event" />
         </template>
       </event>
     </div>

--- a/src/views/CheckoutView.vue
+++ b/src/views/CheckoutView.vue
@@ -8,14 +8,12 @@
           <template v-slot:NoEventsMsg>
             <h3>You have no events in your cart!</h3>
           </template>
-          <template v-slot:eventBtn1="slotProps">
+          <template v-slot:eventBtns="slotProps">
             <router-link
               :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
               class="event-btn" tag="button">
               Event Page
             </router-link>
-          </template>
-          <template v-slot:eventBtn2="slotProps">
             <button
               v-on:click="cancelRegistration({event: slotProps.event})"
               class="event-btn btn--secondary">
@@ -79,6 +77,7 @@ export default {
 
 <style lang="less">
 @import '../../assets/color-constants.less';
+@import '../../assets/global-classes.less';
   .component-container {
     margin: 0 auto;
     display: grid;

--- a/src/views/EventsView.vue
+++ b/src/views/EventsView.vue
@@ -1,36 +1,61 @@
 <template>
-<div>
-  <h1>Our Upcoming Events</h1>
-  <events-list :events="upcomingEvents">
-    <template v-slot:NoEventsMsg>
-      <h3>Sorry, there are no currently available events!</h3>
-    </template>
-    <template v-slot:eventBtn1="slotProps">
-      <button
-        v-on:click="register({event: slotProps.event})"
-        class="event-btn" >
-        Register
-      </button>
-    </template>
-    <template v-slot:eventBtn2="slotProps">
-      <router-link
-        :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
-        class="event-btn btn--secondary" tag="button">
-        Learn More
-      </router-link>
-    </template>
-  </events-list>
+  <div>
+    <p class="title">Our Upcoming Events</p>
+    <events-list :events="upcomingEvents">
+      <template v-slot:NoEventsMsg>
+        <h3>Sorry, there are currently no available events!</h3>
+      </template>
+      <template v-slot:eventBtns="slotProps">
+        <access-control :roles="[USER[ROLE.GP], USER[ROLE.PF]]">
+          <button
+            v-on:click="register({event: slotProps.event})"
+            class="event-btn" >
+            Register
+          </button>
+        </access-control>
+        <access-control :roles="[USER[ROLE.ADMIN]]">
+          <router-link
+              :to="{ name: 'edit-event', params: { eventId: slotProps.event.id}}"
+              class="event-btn" tag="button">
+            Edit
+          </router-link>
+        </access-control>
+        <access-control :roles="[USER[ROLE.ADMIN]]">
+          <router-link
+              :to="{ name: 'create-announcement', params: { eventName: slotProps.event.name}}"
+              class="event-btn" tag="button">
+            Announce
+          </router-link>
+        </access-control>
+        <access-control :roles="[USER[ROLE.GP], USER[ROLE.PF], USER[ROLE.ADMIN]]">
+          <router-link
+            :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
+            class="event-btn btn--secondary" tag="button">
+            Learn More
+          </router-link>
+        </access-control>
+      </template>
+    </events-list>
   </div>
 </template>
 
 <script>
 import { mapState, mapMutations, mapActions } from 'vuex';
 import EventsList from '../components/Events/EventsList.vue';
+import AccessControl from '../components/AccessControl/AccessControl.vue';
+import { ROLE, USER } from '../utils/constants/user';
 
 export default {
   name: 'EventsView',
   components: {
     EventsList,
+    AccessControl,
+  },
+  data() {
+    return {
+      USER,
+      ROLE,
+    };
   },
   async created() {
     await this.setUpcomingEvents();
@@ -57,5 +82,10 @@ export default {
 </script>
 
 <style lang="less" scoped>
-@import '../../assets/global-classes.less';
+  @import '../../assets/global-classes.less';
+
+  .title {
+    text-align: left;
+    font-size: 2.3rem;
+  }
 </style>

--- a/src/views/MyEventsView.vue
+++ b/src/views/MyEventsView.vue
@@ -1,39 +1,34 @@
 <template>
   <div>
-    <h1>My Events</h1>
-    <h3>Here are the events you have registered for</h3>
-    <div class="scroll-container">
-      <events-list-scroll :events="myEvents">
-        <template v-slot:noEventsMsg>
-          <h3>Currently, you are signed up for no events!</h3>
-        </template>
-        <template v-slot:eventBtn1="slotProps">
-          <router-link
-                  :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
-                  class="event-btn btn--secondary" tag="button">
-            Learn More
-          </router-link>
-        </template>
-        <template v-slot:eventBtn2="slotProps">
-          <button
-                  v-on:click="cancelRegistration(slotProps.event)"
-                  class="event-btn btn--secondary">
-            Cancel
-          </button>
-        </template>
-      </events-list-scroll>
-    </div>
+    <p class="title">My Upcoming Events</p>
+    <events-list :events="myEvents">
+      <template v-slot:noEventsMsg>
+        <h3>Currently, you are signed up for no events!</h3>
+      </template>
+      <template v-slot:eventBtns="slotProps">
+        <button
+            v-on:click="cancelRegistration(slotProps.event)"
+            class="event-btn">
+          Cancel
+        </button>
+        <router-link
+            :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
+            class="event-btn btn--secondary" tag="button">
+          Learn More
+        </router-link>
+      </template>
+    </events-list>
   </div>
 </template>
 
 <script>
 import { mapState, mapActions } from 'vuex';
-import EventsListScroll from '../components/Events/EventsListScroll.vue';
+import EventsList from '../components/Events/EventsList.vue';
 
 export default {
   name: 'MyEvents',
   components: {
-    EventsListScroll,
+    EventsList,
   },
   async created() {
     await this.setMyEventsFromNow();
@@ -54,13 +49,11 @@ export default {
 };
 </script>
 
-<style>
-  .scroll-container {
-    position: relative;
-    margin: 0 auto;
-    overflow-x: hidden;
-    overflow-y: auto;
-    max-height: 40rem;
-    max-width: 55rem;
+<style lang="less" scoped>
+  @import '../../assets/global-classes.less';
+
+  .title {
+    text-align: left;
+    font-size: 2.3rem;
   }
 </style>

--- a/tests/e2e/specs/navigation.js
+++ b/tests/e2e/specs/navigation.js
@@ -25,7 +25,7 @@ describe('Testing Navigation', () => {
 
     // checkout
     cy.visit(checkoutPath);
-    cy.contains('p', 'My Cart');
+    cy.contains('h1', 'My Cart');
 
     // profile
     cy.visit(profilePath);
@@ -33,7 +33,7 @@ describe('Testing Navigation', () => {
 
     // registrations
     cy.visit(registrationsPath);
-    cy.contains('h1', 'My Events');
+    cy.contains('p', 'My Upcoming Events');
   });
 
   // it('Visits all pages from landing page', () => {

--- a/tests/e2e/specs/navigation.js
+++ b/tests/e2e/specs/navigation.js
@@ -21,11 +21,11 @@ describe('Testing Navigation', () => {
 
     // events
     cy.visit(eventsPath);
-    cy.contains('h1', 'Our Upcoming Events');
+    cy.contains('p', 'Our Upcoming Events');
 
     // checkout
     cy.visit(checkoutPath);
-    cy.contains('h1', 'My Cart');
+    cy.contains('p', 'My Cart');
 
     // profile
     cy.visit(profilePath);


### PR DESCRIPTION
Lots of changes to make things look nicer. We're going to phase out the event scroll list and instead use the same list for everything. 
- cleaned up the pagination on event list
- Removed the admin controls from the bottom of the events
- Events now just take a list of buttons to display on the right side. EACH BUTTON should be wrapped in its own access-control component so that the flex styling works right.
- Taking button control out of Event.vue and into the calling EventsView/UpcomingEventsView

Checkout event list still needs some work to make the styling nice

![event-list-mine-pf](https://user-images.githubusercontent.com/30527441/82343955-77733c00-99c1-11ea-9be1-5221bd875771.JPG)
![event-list-upcoming-admin](https://user-images.githubusercontent.com/30527441/82343957-77733c00-99c1-11ea-865e-95d2f29a99e2.JPG)
![event-list-upcoming-pf](https://user-images.githubusercontent.com/30527441/82343958-77733c00-99c1-11ea-8952-2c71f4fee870.JPG)
