### PR TITLE
Refactor button styling

### DIFF
--- a/assets/color-constants.less
+++ b/assets/color-constants.less
@@ -11,3 +11,8 @@
 @green-apple: #5FBD5C;
 @tangerine: #FBA34A;
 
+@blue-btn-color: #3489B3;
+@blue-btn-color-dark: #1C485F;
+@orange-btn-color: #F7941D;
+@orange-btn-color-dark: #9D5906;
+

--- a/assets/color-constants.less
+++ b/assets/color-constants.less
@@ -11,8 +11,9 @@
 @green-apple: #5FBD5C;
 @tangerine: #FBA34A;
 
-@blue-btn-color: #3489B3;
-@blue-btn-color-dark: #1C485F;
+@blue-btn-light: #CADCE6;
+@blue-btn-color: #82C2E5;
+@blue-btn-color-dark: #3489B3;
 @orange-btn-color: #F7941D;
 @orange-btn-color-dark: #9D5906;
 

--- a/assets/global-classes.less
+++ b/assets/global-classes.less
@@ -118,6 +118,11 @@ button:focus {
   background-color: @blue-btn-color-dark;
 }
 
+.btn--primary-blue:disabled {
+  background-color: @blue-btn-light;
+  cursor: auto;
+}
+
 .btn--primary-orange {
   .btn--base;
   background-color: @orange-btn-color;
@@ -173,6 +178,17 @@ button:focus {
 .btn--warning:disabled {
   .btn--warning;
   cursor: not-allowed;
+  border-color: #FF8888;
+  background-color: #FF8888;
+}
+
+
+.info-btn {
+  cursor: pointer;
+  border: 1px solid black;
+  border-radius: 50%;
+  margin-left: 0.5em;
+  font-weight: bold;
 }
 
 // -------------- FORMS & INPUT ------------------
@@ -337,5 +353,3 @@ textarea.input-primary {
   font-family: 'Dekko';
   font-size: 22px;
 }
-
-

--- a/assets/global-classes.less
+++ b/assets/global-classes.less
@@ -156,6 +156,25 @@ button:focus {
   color: white;
 }
 
+.btn--warning {
+  .btn--base;
+  background-color: red;
+  border: 1px solid red;
+  color: white;
+}
+
+.btn--warning:hover {
+  .btn--base;
+  background-color: darkred;
+  border: 1px solid darkred;
+  color: white;
+}
+
+.btn--warning:disabled {
+  .btn--warning;
+  cursor: not-allowed;
+}
+
 // -------------- FORMS & INPUT ------------------
 
 .form-title {

--- a/assets/global-classes.less
+++ b/assets/global-classes.less
@@ -1,6 +1,7 @@
 @import './color-constants.less';
 @import url('https://fonts.googleapis.com/css2?family=Dekko&display=swap.css');
 @import url('https://fonts.googleapis.com/css2?family=Quicksand&display=swap.css');
+@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;500&display=swap.css');
 
 h1 {
   margin-left: 8em;
@@ -86,7 +87,75 @@ h1 {
 }
 
 
-// --------------Events Classes---------------
+// -------------- Buttons ---------------
+
+button:focus {
+  // remove that pesky outline from around boxes when they're clicked
+  outline: none;
+}
+
+/* never used on an actual button. Include code that repeats for buttons here and call as a mixin */
+.btn--base {
+  cursor: pointer;
+  font-family: 'Raleway', sans-serif;
+  font-weight: 500;
+  font-size: 1rem;
+  border: none;
+  border-radius: 6px;
+  padding: .5rem 1rem .5rem 1rem;
+  color: white;
+  transition: .3s;
+  width: 10rem;
+  box-sizing: border-box;
+}
+
+.btn--primary-blue {
+  .btn--base;
+  background-color: @blue-btn-color;
+}
+
+.btn--primary-blue:hover {
+  transition: .3s;
+  background-color: @blue-btn-color-dark;
+}
+
+.btn--primary-orange {
+  .btn--base;
+  background-color: @orange-btn-color;
+}
+
+.btn--primary-orange:hover {
+  transition: .3s;
+  background-color: @orange-btn-color-dark;
+}
+
+.btn--secondary-blue {
+  .btn--base;
+  background-color: white;
+  border: 1px solid @blue-btn-color;
+  color: @blue-btn-color;
+}
+
+.btn--secondary-blue:hover {
+  .btn--base;
+  background-color: @blue-btn-color-dark;
+  border: 1px solid @blue-btn-color-dark;
+  color: white;
+}
+
+.btn--secondary-orange {
+  .btn--base;
+  background-color: white;
+  border: 1px solid @orange-btn-color;
+  color: @orange-btn-color;
+}
+
+.btn--secondary-orange:hover {
+  .btn--base;
+  background-color: @orange-btn-color-dark;
+  border: 1px solid @orange-btn-color-dark;
+  color: white;
+}
 
 .event-side-btn {
   width: 10rem;
@@ -362,3 +431,5 @@ textarea.input-primary {
   font-family: 'Dekko';
   font-size: 22px;
 }
+
+

--- a/assets/global-classes.less
+++ b/assets/global-classes.less
@@ -86,7 +86,6 @@ h1 {
   font-size: 2.3rem;
 }
 
-
 // -------------- Buttons ---------------
 
 button:focus {
@@ -105,7 +104,7 @@ button:focus {
   padding: .5rem 1rem .5rem 1rem;
   color: white;
   transition: .3s;
-  width: 10rem;
+  min-width: 10rem;
   box-sizing: border-box;
 }
 
@@ -157,100 +156,6 @@ button:focus {
   color: white;
 }
 
-.event-side-btn {
-  width: 10rem;
-  padding: 0.5rem 1rem;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.submit-btn {
-  width: 30%;
-  padding: 5px 0;
-  margin: 10px 0 1em;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-.create-form-btn {
-  border-radius: 6px;
-  font-size: 1.3rem;
-  padding: 0 12px;
-  cursor: pointer;
-}
-
-.back-btn {
-  cursor: pointer;
-  outline: none;
-  border-radius: 4px;
-  font-size: 1rem;
-  padding: 0 1em;
-  margin-right: 6%;
-}
-
-.info-btn {
-  cursor: pointer;
-  background: none;
-  outline: none;
-  border: 1px solid black;
-  border-radius: 50%;
-  margin-left: 0.5em;
-  font-weight: bold;
-}
-
-.btn {
-  border: 0;
-  background: 0;
-  border-radius: 6px;
-  cursor: pointer;
-  padding: .5rem;
-}
-
-.btn--primary {
-  background-color: @button-bg;
-  color: white;
-  border: 1px solid @button-bg;
-}
-
-.btn--primary:disabled {
-  cursor: auto;
-  background-color: @button-bg-disabled;
-  border: 1px solid @button-bg-disabled;
-}
-
-.btn--primary-selected {
-  color: @button-color;
-  background-color: @green-apple;
-  border: 1px solid @green-apple;
-}
-
-.btn--disabled {
-  color: @button-color;
-  background-color: darkgrey;
-  border: 1px solid darkgrey;
-}
-
-.btn--secondary {
-   color: @tangerine;
-   background-color: @button-color;
-   border: 1px solid @tangerine;
- }
-
-.btn--secondary-selected {
-  color: @button-color;
-  background-color: @tangerine;
-  border: 1px solid @tangerine;
-}
-
-.btn--tertiary {
-  color: white;
-  background-color: @tangerine;
-  border: 1px solid @tangerine;
-}
-
-
 // -------------- FORMS & INPUT ------------------
 
 .form-title {
@@ -294,6 +199,7 @@ textarea.input-primary {
   align-items: center;
   justify-content: space-between;
 }
+
 .pronoun-btn {
   border: 2px solid #888;
   border-radius: 4px;
@@ -396,25 +302,6 @@ textarea.input-primary {
   -webkit-transform: rotate(45deg);
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
-}
-
-.form-btn-basic {
-  border: 2px solid black;
-  border-radius: 2px;
-  padding: .5rem;
-  cursor: pointer;
-}
-
-.unselected-form-btn {
-  border: 2px solid black;
-  border-radius: 2px;
-  background-color: @button-bg;
-}
-
-.selected-form-btn {
-  background: @tangerine;
-  border: 2px solid @tangerine;
-  color: white;
 }
 
 .error-input {

--- a/src/components/Checkout/PaymentSummary.vue
+++ b/src/components/Checkout/PaymentSummary.vue
@@ -5,7 +5,7 @@
         <h3>Taxes: ${{taxes.toFixed(2)}}</h3>
         <h3>Total: ${{totalPrice.toFixed(2)}}</h3>
         <button
-          class="event-btn btn--primary"
+          class="btn--primary-blue"
           v-on:click="clicked">Proceed to checkout</button>
     </div>
 </template>
@@ -39,8 +39,4 @@ export default {
 
 <style lang="less" scoped>
 @import '../../../assets/color-constants.less';
-    .btn--primary {
-        color: white;
-        background-color: @green-apple;
-    }
 </style>

--- a/src/components/Events/EventForm.vue
+++ b/src/components/Events/EventForm.vue
@@ -130,7 +130,7 @@
       </div>
       <div class="form-box box-buttons">
         <button type="submit"
-                class="create-form-btn btn--primary"
+                class="btn--primary-blue"
                 :disabled="imageUploaded === 1 || imageUploaded === 4">
           {{ submitName }}
         </button>

--- a/src/components/Events/EventsList.vue
+++ b/src/components/Events/EventsList.vue
@@ -13,7 +13,7 @@
           <div>
             <div
                 v-if="!firstPage"
-                class='btn--tertiary pagination__btn'
+                class='btn--primary-orange'
                 v-on:click='decrementCurrentPage'>
               Previous Page
             </div>
@@ -22,7 +22,7 @@
           <div>
             <div
                 v-if="!lastPage"
-                class='btn--tertiary pagination__btn'
+                class='btn--primary-orange'
                 v-on:click='incrementCurrentPage'>
               Next Page
             </div>
@@ -103,12 +103,5 @@ export default {
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
-  }
-
-  .pagination__btn {
-    margin: 0;
-    padding: 6px 3px;
-    border-radius: 6px;
-    cursor: pointer;
   }
 </style>

--- a/src/components/Modals/EventModal.vue
+++ b/src/components/Modals/EventModal.vue
@@ -28,14 +28,14 @@
           </button>
           <button
               v-if="cartTickets > 0 && tickets === 0"
-              class="btn--primary-blue"
+              class="btn--primary-orange"
               @click="add"
           >
             Remove From Cart
           </button>
           <button
               v-else
-              class="btn--primary-orange"
+              class="btn--primary-blue"
               @click="add"
               :disabled="tickets < 1"
           >

--- a/src/components/Modals/EventModal.vue
+++ b/src/components/Modals/EventModal.vue
@@ -21,21 +21,21 @@
         </div>
         <div class="btn-bar">
           <button
-              class="btn--secondary event-modal-btn"
+              class="btn--secondary-orange"
               @click="cancel"
           >
             Cancel
           </button>
           <button
               v-if="cartTickets > 0 && tickets === 0"
-              class="btn--primary event-modal-btn"
+              class="btn--primary-blue"
               @click="add"
           >
             Remove From Cart
           </button>
           <button
               v-else
-              class="btn--primary event-modal-btn"
+              class="btn--primary-orange"
               @click="add"
               :disabled="tickets < 1"
           >

--- a/src/components/Modals/EventRegistrationModal.vue
+++ b/src/components/Modals/EventRegistrationModal.vue
@@ -31,12 +31,12 @@
         </div>
         <div class="btn-bar">
           <button
-              class="btn--secondary event-modal-btn"
+              class="btn--secondary-orange"
               @click="cancel"
           >
             Cancel
           </button>
-          <button class="btn--primary event-modal-btn"
+          <button class="btn--primary-orange"
                   @click="checkout"
                   :disabled="ticketDelta === 0">
             {{ checkoutMessage }}

--- a/src/components/Modals/EventRegistrationModal.vue
+++ b/src/components/Modals/EventRegistrationModal.vue
@@ -36,7 +36,7 @@
           >
             Cancel
           </button>
-          <button class="btn--primary-orange"
+          <button class="btn--primary-blue"
                   @click="checkout"
                   :disabled="ticketDelta === 0">
             {{ checkoutMessage }}
@@ -229,4 +229,7 @@ export default {
     cursor: pointer;
   }
 
+  .select-row {
+    text-align: center;
+  }
 </style>

--- a/src/components/TheNavigation.vue
+++ b/src/components/TheNavigation.vue
@@ -75,7 +75,7 @@ export default {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0 1em;
+    padding: 0.5em 1em;
     background: linear-gradient(90deg, rgba(61,168,72,0.92) 0%, rgba(151,244,86,0.83) 100%);
 
     .title {

--- a/src/views/ChangeEmailView.vue
+++ b/src/views/ChangeEmailView.vue
@@ -4,7 +4,7 @@
       <div class="page-title">
         Change Account Email
       </div>
-      <router-link tag="button" class="btn--secondary back-btn" to="/settings">
+      <router-link tag="button" class="btn--secondary-orange" to="/settings">
         Back
       </router-link>
     </div>
@@ -43,7 +43,7 @@
             {{ submitErrors[1] }}
           </div>
         </div>
-        <button type="submit" class="submit-btn btn--tertiary">Update</button>
+        <button type="submit" class="btn--primary-orange">Update</button>
         <div>
           Note that this will change the email associated with the
           primary account owner that receives

--- a/src/views/ChangePasswordlView.vue
+++ b/src/views/ChangePasswordlView.vue
@@ -4,7 +4,7 @@
       <div class="page-title">
         Change Account Password
       </div>
-      <router-link tag="button" class="btn--secondary back-btn" to="/settings">
+      <router-link tag="button" class="btn--secondary-orange" to="/settings">
         Back
       </router-link>
     </div>
@@ -55,7 +55,7 @@
             {{ submitErrors[2] }}
           </div>
         </div>
-        <button type="submit" class="submit-btn btn--tertiary">Update</button>
+        <button type="submit" class="btn--primary-orange">Update</button>
       </form>
     </div>
   </div>

--- a/src/views/CheckoutView.vue
+++ b/src/views/CheckoutView.vue
@@ -14,17 +14,17 @@
               {{ slotProps.event.tickets }} Tickets Reserved
             </div>
             <button v-on:click="openEventModal(slotProps.event)"
-                    class="event-side-btn btn--primary">
+                    class="btn--primary-orange">
               Edit Reservation
             </button>
             <router-link
                 :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
-                class="event-side-btn btn--secondary" tag="button">
+                class="btn--primary-orange" tag="button">
               Event Page
             </router-link>
             <button
                 v-on:click="cancelRegistration({event: slotProps.event})"
-                class="event-side-btn btn--tertiary">
+                class="btn--secondary-orange">
               Remove
             </button>
           </template>

--- a/src/views/CreateAnnouncementView.vue
+++ b/src/views/CreateAnnouncementView.vue
@@ -45,10 +45,10 @@
                 <div class="btn-row">
                     <router-link
                         :to="{ name: 'profile'}"
-                        class="create-form-btn btn--secondary" tag="button">
+                        class="btn--secondary-orange" tag="button">
                         Cancel
                     </router-link>
-                    <button class="create-form-btn btn--primary"
+                    <button class="btn--primary-blue"
                             type="submit">
                         Save
                     </button>

--- a/src/views/DeactivateAccountView.vue
+++ b/src/views/DeactivateAccountView.vue
@@ -94,12 +94,7 @@ export default {
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
-  }
-  .deactivate-btn {
     margin-top: 16px;
-    background-color: red;
-    color: white;
-    font-weight: bold;
   }
 
 </style>

--- a/src/views/DeactivateAccountView.vue
+++ b/src/views/DeactivateAccountView.vue
@@ -4,7 +4,7 @@
       <div class="page-title">
         Deactivate Account
       </div>
-      <router-link tag="button" class="btn--secondary back-btn" to="/settings">
+      <router-link tag="button" class="btn--secondary-orange" to="/settings">
         Back
       </router-link>
     </div>
@@ -25,7 +25,7 @@
           </label>
         </div>
         <div class="btn-row">
-          <button class="submit-btn deactivate-btn"
+          <button class="btn--warning"
                   :disabled="!acknowledged"
                   @click="deactivateAccount">
             Deactivate
@@ -100,10 +100,6 @@ export default {
     background-color: red;
     color: white;
     font-weight: bold;
-  }
-  .deactivate-btn:disabled {
-    background-color: #FF8888;
-    cursor: not-allowed;
   }
 
 </style>

--- a/src/views/EditFamilyInfoView.vue
+++ b/src/views/EditFamilyInfoView.vue
@@ -4,7 +4,7 @@
       <div class="page-title">
         Edit Family Information
       </div>
-      <router-link tag="button" class="btn--secondary back-btn" to="/settings">
+      <router-link tag="button" class="btn--secondary-orange" to="/settings">
         Back
       </router-link>
     </div>
@@ -26,7 +26,7 @@
             <div class="save-label">
               Ready to save?
             </div>
-            <button class="submit-btn btn--primary"
+            <button class="btn--primary-orange"
                     @click="saveInformation">
               Save
             </button>

--- a/src/views/FamilyRequestConfirmation.vue
+++ b/src/views/FamilyRequestConfirmation.vue
@@ -50,7 +50,7 @@
     </div>
     <div>
       <div class="btn-row">
-        <router-link to="/family-requests" class="btn--tertiary action-btn">
+        <router-link to="/family-requests" class="btn--secondary-orange">
           Back To Requests
         </router-link>
       </div>
@@ -141,14 +141,5 @@ export default {
     padding: 0.5em 1em;
     border: 2px solid #888;
     border-radius: 4px;
-  }
-
-  .action-btn {
-    font-size: 0.9rem;
-    border-radius: 4px;
-    padding: 6px 2em;
-    margin-top: 30px;
-    text-decoration: none;
-    cursor: pointer;
   }
 </style>

--- a/src/views/ForgotPasswordRequest.vue
+++ b/src/views/ForgotPasswordRequest.vue
@@ -4,7 +4,7 @@
       <div class="page-title">
         Reset Password
       </div>
-      <router-link tag="button" class="btn--secondary back-btn" to="/login">
+      <router-link tag="button" class="btn--secondary-orange" to="/login">
         Back
       </router-link>
     </div>
@@ -23,7 +23,7 @@
         />
         <div v-if="error" class="error-text">{{ errorMessage }}</div>
       </div>
-      <button @click="submit" class="submit-btn btn--tertiary">Send Link</button>
+      <button @click="submit" class="btn--primary-orange">Send Link</button>
     </div>
   </div>
 </template>

--- a/src/views/ForgotPasswordReset.vue
+++ b/src/views/ForgotPasswordReset.vue
@@ -22,7 +22,7 @@
         />
         <div v-if="error" class="error-text">{{ errorMessage }}</div>
       </div>
-      <button @click="submit" class="submit-btn btn--tertiary">Reset</button>
+      <button @click="submit" class="btn--primary-orange">Reset</button>
     </div>
   </div>
 </template>

--- a/src/views/GpSignUp.vue
+++ b/src/views/GpSignUp.vue
@@ -24,38 +24,38 @@
       <div v-if="hasServerErrors" class="server-error-message">
         There was an error signing you up! Please go back to correct your information.
       </div>
-    </div>
-    <div class="nav-row">
-      <div class="back-btn-box">
-        <div v-if="pageNum > 0">
-          <button @click="backPage" class="btn--primary-orange">
-            Previous Page
-          </button>
+      <div class="nav-row">
+        <div class="back-btn-box">
+          <div v-if="pageNum > 0">
+            <button @click="backPage" class="btn--primary-orange">
+              Previous Page
+            </button>
+          </div>
+          <div v-else>
+            <router-link to="/login" tag="button" class="btn--primary-orange">
+              Back to Login
+            </router-link>
+          </div>
         </div>
-        <div v-else>
-          <router-link to="/login" tag="button" class="btn--primary-orange">
-            Back to Login
-          </router-link>
+        <div class="page-track-box">
+          <div class="page-indicator"
+               :class="{ 'current-page': pageNum === 0, 'error-page': hasServerErrors }"
+          />
+          <div class="page-indicator"
+               :class="{ 'current-page': pageNum === 1 }"
+          />
         </div>
-      </div>
-      <div class="page-track-box">
-        <div class="page-indicator"
-             :class="{ 'current-page': pageNum === 0, 'error-page': hasServerErrors }"
-        />
-        <div class="page-indicator"
-             :class="{ 'current-page': pageNum === 1 }"
-        />
-      </div>
-      <div class="next-btn-box">
-        <div v-if="pageNum < maxPage">
-          <button @click="nextPage" class="btn--primary-orange">
-            Next Page
-          </button>
-        </div>
-        <div v-else>
-          <button @click="submitForm" class="btn--primary-blue">
-            Submit
-          </button>
+        <div class="next-btn-box">
+          <div v-if="pageNum < maxPage">
+            <button @click="nextPage" class="btn--primary-orange">
+              Next Page
+            </button>
+          </div>
+          <div v-else>
+            <button @click="submitForm" class="btn--primary-blue">
+              Submit
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/views/GpSignUp.vue
+++ b/src/views/GpSignUp.vue
@@ -21,42 +21,42 @@
           Something went wrong here...
         </div>
       </div>
-      <div class="nav-row">
-        <div class="back-btn-box">
-          <div v-if="pageNum > 0">
-            <button @click="backPage" class="btn--tertiary submit-btn">
-              Previous Page
-            </button>
-          </div>
-          <div v-else>
-            <router-link to="/login" tag="button" class="btn--tertiary submit-btn">
-              Back to Login
-            </router-link>
-          </div>
-        </div>
-        <div class="page-track-box">
-          <div class="page-indicator"
-               :class="{ 'current-page': pageNum === 0, 'error-page': hasServerErrors }"
-          />
-          <div class="page-indicator"
-               :class="{ 'current-page': pageNum === 1 }"
-          />
-        </div>
-        <div class="next-btn-box">
-          <div v-if="pageNum < maxPage">
-            <button @click="nextPage" class="btn--tertiary submit-btn">
-              Next Page
-            </button>
-          </div>
-          <div v-else>
-            <button @click="submitForm" class="btn--primary submit-btn">
-              Submit
-            </button>
-          </div>
-        </div>
-      </div>
       <div v-if="hasServerErrors" class="server-error-message">
         There was an error signing you up! Please go back to correct your information.
+      </div>
+    </div>
+    <div class="nav-row">
+      <div class="back-btn-box">
+        <div v-if="pageNum > 0">
+          <button @click="backPage" class="btn--primary-orange">
+            Previous Page
+          </button>
+        </div>
+        <div v-else>
+          <router-link to="/login" tag="button" class="btn--primary-orange">
+            Back to Login
+          </router-link>
+        </div>
+      </div>
+      <div class="page-track-box">
+        <div class="page-indicator"
+             :class="{ 'current-page': pageNum === 0, 'error-page': hasServerErrors }"
+        />
+        <div class="page-indicator"
+             :class="{ 'current-page': pageNum === 1 }"
+        />
+      </div>
+      <div class="next-btn-box">
+        <div v-if="pageNum < maxPage">
+          <button @click="nextPage" class="btn--primary-orange">
+            Next Page
+          </button>
+        </div>
+        <div v-else>
+          <button @click="submitForm" class="btn--primary-blue">
+            Submit
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -195,13 +195,15 @@ export default {
   @import '../../assets/color-constants.less';
 
   .nav-row {
+    margin: 0 auto;
     margin-top: 24px;
     display: grid;
-    grid-template-columns: 25% 12.5% 25% 12.5% 25%;
-    grid-template-areas: "back-btn . page-track . next-btn";
+    grid-template-columns: 40% 20% 40%;
+    grid-template-areas: "back-btn page-track next-btn";
     box-sizing: border-box;
     text-align: center;
     align-items: center;
+    width: 30em;
   }
   .back-btn-box {
     grid-area: back-btn;

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -27,7 +27,7 @@
         <div class="error">
           <p v-if="submitted && error" class="error-message">{{error}}</p>
         </div>
-        <button type="submit" class="login-btn submit-btn btn--tertiary">Login</button>
+        <button type="submit" class="btn--primary-orange">Login</button>
       </form>
       <router-link class="forgot-password" to="forgot-password-request" tag="a">
         Forgot your password?

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -27,7 +27,7 @@
         <div class="error">
           <p v-if="submitted && error" class="error-message">{{error}}</p>
         </div>
-        <button type="submit" class="btn--primary-orange">Login</button>
+        <button type="submit" class="btn--primary-orange login-btn">Login</button>
       </form>
       <router-link class="forgot-password" to="forgot-password-request" tag="a">
         Forgot your password?

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -134,9 +134,6 @@ export default {
   margin-bottom: 10px;
 }
 
-.login-btn {
-}
-
 .forgot-password {
   margin-bottom: 3px;
 }

--- a/src/views/MyEventsView.vue
+++ b/src/views/MyEventsView.vue
@@ -11,12 +11,12 @@
         </div>
         <button
             v-on:click="openRegistrationModal(slotProps.event)"
-            class="event-side-btn btn--primary">
+            class="btn--primary-blue">
           Edit Registration
         </button>
         <router-link
             :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
-            class="event-side-btn btn--secondary" tag="button">
+            class="btn--secondary-blue" tag="button">
           Learn More
         </router-link>
       </template>

--- a/src/views/PersonalRequests.vue
+++ b/src/views/PersonalRequests.vue
@@ -4,7 +4,7 @@
       <div class="page-title">
         Participating Family Requests
       </div>
-      <router-link tag="button" class="btn--secondary back-btn" to="/settings">
+      <router-link tag="button" class="btn--secondary-orange" to="/settings">
         Back
       </router-link>
     </div>
@@ -86,7 +86,7 @@
                   once they have made a decision.
                 </div>
                 <div class="submit-btn-row">
-                  <button @click="submitRequest" class="submit-btn btn--primary">
+                  <button @click="submitRequest" class="btn--primary-orange">
                     Apply
                   </button>
                 </div>

--- a/src/views/PfSignUp.vue
+++ b/src/views/PfSignUp.vue
@@ -76,41 +76,41 @@
       <div v-if="hasServerErrors" class="server-error-message">
         There was an error signing you up! Please go back to correct your information.
       </div>
-    </div>
-    <div class="nav-row">
-      <div class="back-btn-box">
-        <div v-if="pageNum > 0">
-          <button @click="backPage" class="btn--primary-orange">
-            Previous Page
-          </button>
+      <div class="nav-row">
+        <div class="back-btn-box">
+          <div v-if="pageNum > 0">
+            <button @click="backPage" class="btn--primary-orange">
+              Previous Page
+            </button>
+          </div>
+          <div v-else>
+            <router-link to="/login" tag="button" class="btn--primary-orange">
+              Back to Login
+            </router-link>
+          </div>
         </div>
-        <div v-else>
-          <router-link to="/login" tag="button" class="btn--primary-orange">
-            Back to Login
-          </router-link>
+        <div class="page-track-box">
+          <div class="page-indicator"
+               :class="{ 'current-page': pageNum === 0, 'error-page': hasServerErrors }"
+          />
+          <div class="page-indicator"
+               :class="{ 'current-page': pageNum === 1 }"
+          />
+          <div class="page-indicator"
+               :class="{ 'current-page': pageNum === 2 }"
+          />
         </div>
-      </div>
-      <div class="page-track-box">
-        <div class="page-indicator"
-             :class="{ 'current-page': pageNum === 0, 'error-page': hasServerErrors }"
-        />
-        <div class="page-indicator"
-             :class="{ 'current-page': pageNum === 1 }"
-        />
-        <div class="page-indicator"
-             :class="{ 'current-page': pageNum === 2 }"
-        />
-      </div>
-      <div class="next-btn-box">
-        <div v-if="pageNum < maxPage">
-          <button @click="nextPage" class="btn--primary-orange">
-            Next Page
-          </button>
-        </div>
-        <div v-else>
-          <button @click="submitForm" class="btn--primary-blue">
-            Submit
-          </button>
+        <div class="next-btn-box">
+          <div v-if="pageNum < maxPage">
+            <button @click="nextPage" class="btn--primary-orange">
+              Next Page
+            </button>
+          </div>
+          <div v-else>
+            <button @click="submitForm" class="btn--primary-blue">
+              Submit
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/views/PfSignUp.vue
+++ b/src/views/PfSignUp.vue
@@ -73,45 +73,45 @@
           Something went wrong here...
         </div>
       </div>
-      <div class="nav-row">
-        <div class="back-btn-box">
-          <div v-if="pageNum > 0">
-            <button @click="backPage" class="btn--tertiary submit-btn">
-              Previous Page
-            </button>
-          </div>
-          <div v-else>
-            <router-link to="/login" tag="button" class="btn--tertiary submit-btn">
-              Back to Login
-            </router-link>
-          </div>
-        </div>
-        <div class="page-track-box">
-          <div class="page-indicator"
-               :class="{ 'current-page': pageNum === 0, 'error-page': hasServerErrors }"
-          />
-          <div class="page-indicator"
-               :class="{ 'current-page': pageNum === 1 }"
-          />
-          <div class="page-indicator"
-               :class="{ 'current-page': pageNum === 2 }"
-          />
-        </div>
-        <div class="next-btn-box">
-          <div v-if="pageNum < maxPage">
-            <button @click="nextPage" class="btn--tertiary submit-btn">
-              Next Page
-            </button>
-          </div>
-          <div v-else>
-            <button @click="submitForm" class="btn--primary submit-btn">
-              Submit
-            </button>
-          </div>
-        </div>
-      </div>
       <div v-if="hasServerErrors" class="server-error-message">
         There was an error signing you up! Please go back to correct your information.
+      </div>
+    </div>
+    <div class="nav-row">
+      <div class="back-btn-box">
+        <div v-if="pageNum > 0">
+          <button @click="backPage" class="btn--primary-orange">
+            Previous Page
+          </button>
+        </div>
+        <div v-else>
+          <router-link to="/login" tag="button" class="btn--primary-orange">
+            Back to Login
+          </router-link>
+        </div>
+      </div>
+      <div class="page-track-box">
+        <div class="page-indicator"
+             :class="{ 'current-page': pageNum === 0, 'error-page': hasServerErrors }"
+        />
+        <div class="page-indicator"
+             :class="{ 'current-page': pageNum === 1 }"
+        />
+        <div class="page-indicator"
+             :class="{ 'current-page': pageNum === 2 }"
+        />
+      </div>
+      <div class="next-btn-box">
+        <div v-if="pageNum < maxPage">
+          <button @click="nextPage" class="btn--primary-orange">
+            Next Page
+          </button>
+        </div>
+        <div v-else>
+          <button @click="submitForm" class="btn--primary-blue">
+            Submit
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -369,13 +369,15 @@ export default {
   }
 
   .nav-row {
+    margin: 0 auto;
     margin-top: 24px;
     display: grid;
-    grid-template-columns: 25% 12.5% 25% 12.5% 25%;
-    grid-template-areas: "back-btn . page-track . next-btn";
+    grid-template-columns: 40% 20% 40%;
+    grid-template-areas: "back-btn page-track next-btn";
     box-sizing: border-box;
     text-align: center;
     align-items: center;
+    width: 30em;
   }
   .back-btn-box {
     grid-area: back-btn;

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -5,27 +5,27 @@
     </div>
     <div class="auth-container">
       <div class="settings-box">
-        <router-link class="btn--tertiary setting-btn" tag="button" to="/change-email">
+        <router-link class="btn--primary-orange" tag="button" to="/change-email">
           Change Primary Account Email
         </router-link>
       </div>
       <div class="settings-box">
-        <router-link class="btn--tertiary setting-btn" tag="button" to="/change-password">
+        <router-link class="btn--primary-orange" tag="button" to="/change-password">
           Change Password
         </router-link>
       </div>
       <access-control class="settings-box" :roles="[USER[ROLE.GP], USER[ROLE.PF]]">
-        <router-link class="btn--tertiary setting-btn" tag="button" to="/edit-family-information">
+        <router-link class="btn--primary-orange" tag="button" to="/edit-family-information">
           Add or Edit Family Information
         </router-link>
       </access-control>
       <access-control class="settings-box" :roles="[USER[ROLE.GP], USER[ROLE.PF]]">
-        <router-link class="btn--tertiary setting-btn" tag="button" to="/personal-requests">
+        <router-link class="btn--primary-orange" tag="button" to="/personal-requests">
           Request to Become a Participating Family
         </router-link>
       </access-control>
       <access-control class="settings-box" :roles="[USER[ROLE.GP], USER[ROLE.PF]]">
-        <router-link class="btn--tertiary setting-btn" tag="button" to="/deactivate-account">
+        <router-link class="btn--primary-orange" tag="button" to="/deactivate-account">
           Deactivate Account
         </router-link>
       </access-control>
@@ -62,6 +62,10 @@ export default {
 
   .settings-box {
     margin-top: 24px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
   }
 
   .setting-btn {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -67,12 +67,8 @@ export default {
     justify-content: center;
     align-items: center;
   }
-
-  .setting-btn {
-    cursor: pointer;
-    border-radius: 6px;
+  .settings-box > button {
     width: 100%;
-    font-size: 1.3rem;
-    padding: 0.75em 0;
+    padding: 1em 0;
   }
 </style>

--- a/src/views/SignUpLandingView.vue
+++ b/src/views/SignUpLandingView.vue
@@ -4,7 +4,7 @@
       <div class="page-title">
         Create an Account
       </div>
-      <router-link tag="button" class="btn--secondary back-btn" to="/login">
+      <router-link tag="button" class="btn--secondary-orange" to="/login">
         Back
       </router-link>
     </div>
@@ -22,7 +22,7 @@
             </div>
           </div>
           <div class="btn-row">
-            <router-link tag="button" to="sign-up-gp" class="submit-btn btn--tertiary">
+            <router-link tag="button" to="sign-up-gp" class="btn--primary-orange">
               Sign Up
             </router-link>
           </div>
@@ -39,7 +39,7 @@
             </div>
           </div>
           <div class="btn-row">
-            <router-link tag="button" to="sign-up-pf" class="submit-btn btn--tertiary">
+            <router-link tag="button" to="sign-up-pf" class="btn--primary-orange">
               Sign Up
             </router-link>
           </div>

--- a/src/views/SingleEventView.vue
+++ b/src/views/SingleEventView.vue
@@ -99,7 +99,7 @@
           </button>
         </access-control>
         <access-control v-if="ticketsInCart > 0" :roles="[USER[ROLE.GP], USER[ROLE.PF]]">
-          <router-link tag="button" to="/checkout" class="btn--primary single-event-btn">
+          <router-link tag="button" to="/checkout" class="btn--primary-orange">
             Proceed to Cart
           </router-link>
         </access-control>

--- a/src/views/SingleEventView.vue
+++ b/src/views/SingleEventView.vue
@@ -72,12 +72,12 @@
           <router-link
               to="/upcoming-events"
               tag="button"
-              class="btn--secondary single-event-btn">
+              class="btn--primary-orange">
             Back To Events
           </router-link>
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
-          <router-link tag="button"  class="btn--primary single-event-btn"
+          <router-link tag="button"  class="btn--primary-orange"
                        :to="{name: 'create-announcement',
                        params: {eventName: singleEvent.title, eventId: singleEvent.id}}"
           >
@@ -86,14 +86,14 @@
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <button
-              class="btn--primary single-event-btn"
+              class="btn--primary-orange"
               v-on:click="$router.push(`/edit-event/${singleEvent.id}`)">
             Edit Event
           </button>
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <button
-              class="btn--primary single-event-btn"
+              class="btn--primary-orange"
               v-on:click="viewRSVP(singleEvent)">
             Download RSVPs
           </button>
@@ -105,13 +105,13 @@
         </access-control>
         <access-control v-if="singleEvent.ticketCount > 0" :roles="[USER[ROLE.GP], USER[ROLE.PF]]">
           <button @click="openRegistrationModal"
-                  class="btn--primary single-event-btn">
+                  class="btn--primary-orange">
             Edit Registration
           </button>
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <button
-              class="btn--tertiary single-event-btn"
+              class="btn--primary-orange"
               v-on:click="deleteEvent(singleEvent.id), $router.push('/upcoming-events')">
             Delete Event
           </button>

--- a/src/views/SingleEventView.vue
+++ b/src/views/SingleEventView.vue
@@ -17,13 +17,13 @@
               <span class="cart-text">
                 You have {{ ticketsInCart }} tickets in your cart
               </span>
-              <button class="register-button"
+              <button class="btn--primary-orange register-button"
                       @click="openEventModal">
                 Edit Tickets
               </button>
             </div>
             <button v-else
-                    class="register-button"
+                    class="btn--primary-blue register-button"
                     @click="openEventModal">
               Sign Up!
             </button>
@@ -72,12 +72,12 @@
           <router-link
               to="/upcoming-events"
               tag="button"
-              class="btn--primary-orange">
+              class="btn--secondary-orange">
             Back To Events
           </router-link>
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
-          <router-link tag="button"  class="btn--primary-orange"
+          <router-link tag="button"  class="btn--primary-blue"
                        :to="{name: 'create-announcement',
                        params: {eventName: singleEvent.title, eventId: singleEvent.id}}"
           >
@@ -86,20 +86,20 @@
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <button
-              class="btn--primary-orange"
+              class="btn--primary-blue"
               v-on:click="$router.push(`/edit-event/${singleEvent.id}`)">
             Edit Event
           </button>
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <button
-              class="btn--primary-orange"
+              class="btn--primary-blue"
               v-on:click="viewRSVP(singleEvent)">
             Download RSVPs
           </button>
         </access-control>
         <access-control v-if="ticketsInCart > 0" :roles="[USER[ROLE.GP], USER[ROLE.PF]]">
-          <router-link tag="button" to="/checkout" class="btn--primary-orange">
+          <router-link tag="button" to="/checkout" class="btn--primary-blue">
             Proceed to Cart
           </router-link>
         </access-control>

--- a/src/views/UpcomingEventsView.vue
+++ b/src/views/UpcomingEventsView.vue
@@ -50,13 +50,13 @@
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <router-link
               :to="{ name: 'edit-event', params: { eventId: slotProps.event.id}}"
-              class="event-side-btn btn--primary" tag="button">
+              class="btn--primary-blue" tag="button">
             Edit
           </router-link>
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <router-link
-              class="event-side-btn btn--primary"
+              class="btn--primary-blue"
               tag="button"
               :to="{name: 'create-announcement',
                     params: {eventName: slotProps.event.title, eventId: slotProps.event.id}}"
@@ -67,7 +67,7 @@
         <access-control :roles="[USER[ROLE.GP], USER[ROLE.PF], USER[ROLE.ADMIN]]">
           <router-link
             :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
-            class="event-side-btn btn--secondary" tag="button">
+            class="btn--secondary-blue" tag="button">
             Learn More
           </router-link>
         </access-control>

--- a/src/views/UpcomingEventsView.vue
+++ b/src/views/UpcomingEventsView.vue
@@ -49,13 +49,13 @@
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <router-link
-              :to="{ name: 'edit-event', params: { eventId: slotProps.event.id}}"
-              class="btn--primary-blue" tag="button">
+                  style="margin-bottom: 1rem"
+                  :to="{ name: 'edit-event', params: { eventId: slotProps.event.id}}"
+                  class="btn--primary-blue" tag="button">
             Edit
           </router-link>
-        </access-control>
-        <access-control :roles="[USER[ROLE.ADMIN]]">
           <router-link
+              style="margin-bottom: 1rem"
               class="btn--primary-blue"
               tag="button"
               :to="{name: 'create-announcement',

--- a/src/views/UpcomingEventsView.vue
+++ b/src/views/UpcomingEventsView.vue
@@ -65,9 +65,14 @@
           </router-link>
         </access-control>
         <access-control :roles="[USER[ROLE.GP], USER[ROLE.PF], USER[ROLE.ADMIN]]">
+          <button style="margin-bottom: 1rem"
+                  class="btn--primary-blue"
+                  v-on:click="openEventModal(slotProps.event)">
+            Register
+          </button>
           <router-link
             :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
-            class="btn--secondary-blue" tag="button">
+            class="btn--secondary-orange" tag="button">
             Learn More
           </router-link>
         </access-control>

--- a/src/views/UpcomingEventsView.vue
+++ b/src/views/UpcomingEventsView.vue
@@ -27,19 +27,19 @@
         <access-control :roles="[USER[ROLE.GP], USER[ROLE.PF]]">
           <button v-if="slotProps.event.ticketCount > 0"
                   @click="openRegistrationModal(slotProps.event)"
-                  class="event-side-btn btn--primary">
+                  class="btn--primary-orange">
             Edit Registration
           </button>
           <button
               v-else-if="slotProps.event.spotsAvailable === 0"
-              class="event-side-btn sold-out"
+              class="btn--primary-blue"
               disabled>
             Sold Out
           </button>
           <button
             v-else-if="slotProps.event.canRegister"
             v-on:click="openEventModal(slotProps.event)"
-            class="event-side-btn btn--primary" >
+            class="btn--primary-blue" >
             Register
           </button>
           <div v-else>
@@ -49,13 +49,13 @@
         </access-control>
         <access-control :roles="[USER[ROLE.ADMIN]]">
           <router-link
-                  style="margin-bottom: 1rem"
-                  :to="{ name: 'edit-event', params: { eventId: slotProps.event.id}}"
-                  class="btn--primary-blue" tag="button">
+              :to="{ name: 'edit-event', params: { eventId: slotProps.event.id}}"
+              class="btn--primary-blue" tag="button">
             Edit
           </router-link>
+        </access-control>
+        <access-control :roles="[USER[ROLE.ADMIN]]">
           <router-link
-              style="margin-bottom: 1rem"
               class="btn--primary-blue"
               tag="button"
               :to="{name: 'create-announcement',
@@ -65,11 +65,6 @@
           </router-link>
         </access-control>
         <access-control :roles="[USER[ROLE.GP], USER[ROLE.PF], USER[ROLE.ADMIN]]">
-          <button style="margin-bottom: 1rem"
-                  class="btn--primary-blue"
-                  v-on:click="openEventModal(slotProps.event)">
-            Register
-          </button>
           <router-link
             :to="{ name: 'single-event', params: { eventId: slotProps.event.id}}"
             class="btn--secondary-orange" tag="button">


### PR DESCRIPTION
We now don't have a confusing medley of different button classes (including a tertiary button? That was me originally sorry about that). There are two simple buttons. A primary orange, primary blue, secondary orange, and secondary blue. Primary buttons have a solid fill background and white text. Secondary buttons have a white background, colored border, and colored text. Hovering has a smooth transition from light to dark color. See:

Old:
![old-btn](https://user-images.githubusercontent.com/20273689/83936433-96c7e280-a791-11ea-9b18-66a2baa4a50d.JPG)

New:
![new-btn](https://user-images.githubusercontent.com/20273689/83936434-99c2d300-a791-11ea-8fc2-0396180ef304.JPG)

New on hover:
![new-btn-hover](https://user-images.githubusercontent.com/20273689/83936449-a6dfc200-a791-11ea-941e-604a6a5a7bb5.JPG)


Old blue:
![old-create-event-btn](https://user-images.githubusercontent.com/20273689/83936437-9e878700-a791-11ea-89e8-f9ce88735d7a.JPG)

New blue:
![new-create-event-btn](https://user-images.githubusercontent.com/20273689/83936442-a2b3a480-a791-11ea-9a56-118145b94eef.JPG)

New blue on hover:
![new-btn-hover-blue](https://user-images.githubusercontent.com/20273689/83936451-ab0bdf80-a791-11ea-8788-327e427ed5ae.JPG)
