### PR TITLE
minor date validation fix (allows users to create an event for a later time today)

### DIFF
--- a/src/components/Events/EventForm.vue
+++ b/src/components/Events/EventForm.vue
@@ -289,7 +289,7 @@ export default {
 
       if (this.eventDate.length === 0) {
         newSubmitErrors.eventDate = 'required';
-      } else if (DateUtils.isInPast(this.eventDate)) {
+      } else if (DateUtils.isInPast(this.eventDate, this.startTime)) {
         newSubmitErrors.eventDate = 'event date must be in the future';
       }
 

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -21,8 +21,9 @@ function stringDateFiveDaysBefore(date) {
   return toStringDate(d);
 }
 
-function isInPast(date) {
-  const d = moment(date);
+function isInPast(date, start) {
+  const str = date.concat(', ', start);
+  const d = moment(str, 'YYYY-MM-DD, HH:mm');
   return d.isBefore();
 }
 


### PR DESCRIPTION
I wasn't able to recreate the bug in this ticket (https://trello.com/c/7Geei6bd), but I did notice that you can't create an event that's happening on the current date (today) at a later time, so that was a super quick fix in DateUtils.