### PR TITLE
Zo announcements store refactor

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_API_DOMAIN = https://llb-travis.c4cneu.com
+VUE_APP_API_DOMAIN = http://localhost:8081
 VUE_APP_STRIPE_PUBLISHABLE_KEY = pk_test_Fo9mg4lIIv6tUmJfzFMjdgpa

--- a/src/components/Announcements/AnnouncementsList.vue
+++ b/src/components/Announcements/AnnouncementsList.vue
@@ -18,8 +18,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import DateUtils from '../../utils/DateUtils';
-import api from '../../api/api';
 
 export default {
   /* TODO: This component should probably just be for site-wide announcements */
@@ -29,23 +29,7 @@ export default {
     count: Number, // count needed if and only if sitewide
     eventID: Number, // eventID needed if and only if NOT sitewide
   },
-  data() {
-    return {
-      announcements: [],
-    };
-  },
   methods: {
-    async getAnnouncements() {
-      let res;
-      if (this.sitewide) {
-        res = await api.getSitewideAnnouncements({
-          count: this.count,
-        });
-      } else {
-        res = await api.getEventAnnouncements(this.eventID);
-      }
-      return res.announcements;
-    },
     toStringDate(date) {
       return DateUtils.toStringDate(date);
     },
@@ -53,8 +37,13 @@ export default {
       this.$emit('open-announcement', a);
     },
   },
-  async created() {
-    this.announcements = await this.getAnnouncements();
+  computed: {
+    ...mapState('announcements', {
+      announcements: 'announcements',
+    }),
+  },
+  created() {
+    this.$store.dispatch('announcements/loadSitewideAnnouncements');
   },
 };
 </script>

--- a/src/components/Announcements/AnnouncementsList.vue
+++ b/src/components/Announcements/AnnouncementsList.vue
@@ -9,6 +9,7 @@
       <div class="announcement-card">
         <div class="announce-header">
           <div class="announce-title">{{a.title}}</div>
+          <div>{{"id " + a.id}}</div>
           <div class="announce-date">{{ toStringDate(a.created) }}</div>
         </div>
         <div class="announce-body">{{a.description}}</div>

--- a/src/components/Modals/AnnouncementModal.vue
+++ b/src/components/Modals/AnnouncementModal.vue
@@ -10,7 +10,8 @@
           {{announcement.description}}
           <access-control :roles="[USER[ROLE.ADMIN]]">
             <br/>
-            <button class="btn--warning" @click="deleteAnnouncement">Delete</button>
+            <button class="btn--warning"
+                    @click="deleteAnnouncement(announcement.id)">Delete</button>
           </access-control>
         </div>
         <div
@@ -27,7 +28,6 @@
 <script>
 import DateUtils from '../../utils/DateUtils';
 import AccessControl from '../AccessControl/AccessControl.vue';
-import api from '../../api/api';
 import { ROLE, USER } from '../../utils/constants/user';
 
 export default {
@@ -39,6 +39,7 @@ export default {
     },
     announcement: {
       type: Object,
+      required: true,
     },
   },
   data() {
@@ -62,15 +63,9 @@ export default {
     toStringDate(date) {
       return DateUtils.toStringDate(date);
     },
-    async deleteAnnouncement() {
-      try {
-        await api.deleteAnnouncement(this.announcement.id);
-        this.$emit('close-announcement');
-        this.$emit('delete-announcement');
-      } catch (e) {
-        // eslint-disable-next-line
-        alert("Error: " + e);
-      }
+    deleteAnnouncement(announcementId) {
+      this.$store.dispatch('announcements/deleteAnnouncement', announcementId);
+      this.close();
     },
   },
 };

--- a/src/store/modules/announcements.js
+++ b/src/store/modules/announcements.js
@@ -8,26 +8,30 @@ export default {
   getters: {
     getSitewideAnnouncements(state) {
       return state.announcements.filter(
-        ann => !("event_id" in ann));
+        ann => !('event_id' in ann),
+      );
     },
     getEventAnnouncements(state, eventId) {
       return state.announcements.filter(
-        ann => ("event_id" in ann) && ann['event_id'] === eventId);
-    }
+        ann => ('event_id' in ann) && ann.event_id === eventId,
+      );
+    },
   },
   mutations: {
     loadAnnouncements(state, { announcements }) {
-      state.announcements.push(announcements);
+      state.announcements = [];
+      announcements.forEach((ann) => {
+        state.announcements.push(ann);
+      });
     },
     removeAnnouncement(state, payload) {
-      state.announcements =
-        state
+      state.announcements = state
         .announcements
         .filter(ann => ann.id !== payload.announcementId);
     },
     clearAnnouncements(state) {
       state.announcements = [];
-    }
+    },
   },
   actions: {
     async loadSitewideAnnouncements({ commit }) {
@@ -40,7 +44,7 @@ export default {
     },
     async deleteAnnouncement({ commit }, { announcementId }) {
       await api.deleteAnnouncement(announcementId);
-      commit('removeAnnouncement', { announcementId })
-    }
+      commit('removeAnnouncement', { announcementId });
+    },
   },
 };

--- a/src/store/modules/announcements.js
+++ b/src/store/modules/announcements.js
@@ -19,9 +19,10 @@ export default {
   },
   mutations: {
     loadAnnouncements(state, { announcements }) {
-      state.announcements = [];
       announcements.forEach((ann) => {
-        state.announcements.push(ann);
+        if (state.announcements.filter(a => a.id === ann.id).length === 0) {
+          state.announcements.push(ann);
+        }
       });
     },
     removeAnnouncement(state, payload) {

--- a/src/store/modules/announcements.js
+++ b/src/store/modules/announcements.js
@@ -42,8 +42,9 @@ export default {
       const response = await api.getEventAnnouncements(eventId);
       commit('loadAnnouncements', { announcements: response.announcements });
     },
-    async deleteAnnouncement({ commit }, { announcementId }) {
-      await api.deleteAnnouncement(announcementId);
+    async deleteAnnouncement({ commit }, announcementId) {
+      const response = await api.deleteAnnouncement(announcementId);
+      console.log(response);
       commit('removeAnnouncement', { announcementId });
     },
   },

--- a/src/store/modules/announcements.js
+++ b/src/store/modules/announcements.js
@@ -25,7 +25,8 @@ export default {
       });
     },
     removeAnnouncement(state, payload) {
-      state.announcements = state
+      state.announcements =
+        state
         .announcements
         .filter(ann => ann.id !== payload.announcementId);
     },
@@ -44,7 +45,6 @@ export default {
     },
     async deleteAnnouncement({ commit }, announcementId) {
       const response = await api.deleteAnnouncement(announcementId);
-      console.log(response);
       commit('removeAnnouncement', { announcementId });
     },
   },

--- a/src/store/modules/announcements.js
+++ b/src/store/modules/announcements.js
@@ -25,8 +25,7 @@ export default {
       });
     },
     removeAnnouncement(state, payload) {
-      state.announcements =
-        state
+      state.announcements = state
         .announcements
         .filter(ann => ann.id !== payload.announcementId);
     },
@@ -39,12 +38,12 @@ export default {
       const response = await api.getSitewideAnnouncements();
       commit('loadAnnouncements', { announcements: response.announcements });
     },
-    async loadEventAnnouncements({ commit }, { eventId }) {
+    async loadEventAnnouncements({ commit }, eventId) {
       const response = await api.getEventAnnouncements(eventId);
       commit('loadAnnouncements', { announcements: response.announcements });
     },
     async deleteAnnouncement({ commit }, announcementId) {
-      const response = await api.deleteAnnouncement(announcementId);
+      await api.deleteAnnouncement(announcementId);
       commit('removeAnnouncement', { announcementId });
     },
   },

--- a/src/store/modules/announcements.js
+++ b/src/store/modules/announcements.js
@@ -1,0 +1,46 @@
+import api from '../../api/api';
+
+export default {
+  namespaced: true,
+  state: {
+    announcements: [],
+  },
+  getters: {
+    getSitewideAnnouncements(state) {
+      return state.announcements.filter(
+        ann => !("event_id" in ann));
+    },
+    getEventAnnouncements(state, eventId) {
+      return state.announcements.filter(
+        ann => ("event_id" in ann) && ann['event_id'] === eventId);
+    }
+  },
+  mutations: {
+    loadAnnouncements(state, { announcements }) {
+      state.announcements.push(announcements);
+    },
+    removeAnnouncement(state, payload) {
+      state.announcements =
+        state
+        .announcements
+        .filter(ann => ann.id !== payload.announcementId);
+    },
+    clearAnnouncements(state) {
+      state.announcements = [];
+    }
+  },
+  actions: {
+    async loadSitewideAnnouncements({ commit }) {
+      const response = await api.getSitewideAnnouncements();
+      commit('loadAnnouncements', { announcements: response.announcements });
+    },
+    async loadEventAnnouncements({ commit }, { eventId }) {
+      const response = await api.getEventAnnouncements(eventId);
+      commit('loadAnnouncements', { announcements: response.announcements });
+    },
+    async deleteAnnouncement({ commit }, { announcementId }) {
+      await api.deleteAnnouncement(announcementId);
+      commit('removeAnnouncement', { announcementId })
+    }
+  },
+};

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 
+import announcements from './modules/announcements';
 import events from './modules/events';
 import cart from './modules/cart';
 import user from './modules/user';
@@ -11,6 +12,7 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   namespaced: true,
   modules: {
+    announcements,
     events,
     cart,
     user,
@@ -18,6 +20,7 @@ export default new Vuex.Store({
   },
   actions: {
     clearAll({ commit }) {
+      commit('announcements/clearAnnouncements');
       commit('events/resetEvents');
       commit('cart/clearCart');
       commit('user/resetUser');

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -61,15 +61,13 @@
         <announcements-list
             sitewide
             :count="announcementsCount"
-            :key="announcementsListKey"
             @open-announcement="openAnnouncementModal"/>
       </div>
     </div>
     <AnnouncementModal
         :open="openModal"
         :announcement="modalAnnouncement"
-        @close-announcement="closeAnnouncementModal"
-        @delete-announcement="deleteAnnouncement"/>
+        @close-announcement="closeAnnouncementModal"/>
   </div>
 </template>
 
@@ -90,7 +88,6 @@ export default {
       ROLE,
       openModal: false,
       modalAnnouncement: null,
-      announcementsListKey: 0, // arb. val that reloads announcements-list component when changed
     };
   },
   components: {
@@ -113,9 +110,6 @@ export default {
     },
     closeAnnouncementModal() {
       this.openModal = false;
-    },
-    deleteAnnouncement() {
-      this.announcementsListKey += 1; // reloads the announcements-list component
     },
     async logout() {
       try {

--- a/src/views/SingleEventView.vue
+++ b/src/views/SingleEventView.vue
@@ -251,7 +251,7 @@ export default {
   },
   async created() {
     await this.getSingleEvent();
-    await this.getEventAnnouncements();
+    await this.$store.dispatch('announcements/loadEventAnnouncements', this.eventId);
   },
 };
 </script>


### PR DESCRIPTION
this branch is abstracting away working with the announcements API into the Vuex store. This will make it so we don't have to do things like force reload the announcements list component when deleting or otherwise editing announcements.