### PR TITLE
Text Changes, GM/PF Box Placement, Vaccine Checkbox

### DIFF
--- a/src/components/Forms/AgreementsForm.vue
+++ b/src/components/Forms/AgreementsForm.vue
@@ -31,16 +31,6 @@
           </span>
         </label>
       </div>
-      <div class="checkbox-container">
-        <label class="checkbox-label">
-          <input type="checkbox" v-model="value.upToDateVaccination">
-          <span class="checkmark"
-                :class="{ 'error-input': !!submitErrors.upToDateVaccination }"/>
-          <span class="checkbox-message">
-            My children are up to date on all vaccinations.
-          </span>
-        </label>
-      </div>
     </div>
     <div class="instruction-text">
       Photo and Video Release
@@ -90,9 +80,6 @@ export default {
       }
       if (!this.value.parentsRemain) {
         newSubmitErrors.parentsRemain = 'required';
-      }
-      if (!this.value.upToDateVaccination) {
-        newSubmitErrors.upToDateVaccination = 'required';
       }
       if (!this.value.photoVideoReleaseConsent) {
         newSubmitErrors.photoVideoReleaseConsent = 'required';

--- a/src/components/Forms/ChildForm.vue
+++ b/src/components/Forms/ChildForm.vue
@@ -99,7 +99,7 @@
       <div class="half-input">
         <div class="input-box">
           <label class="input-label">
-            School Year
+            Grade
             <input v-model="value.schoolYear"
                    :disabled="disableChange"
                    type="text"

--- a/src/views/SignUpLandingView.vue
+++ b/src/views/SignUpLandingView.vue
@@ -13,16 +13,18 @@
         <div class="option-container auth-container">
           <div>
             <div class="form-title">
-              General Member
+              Participating Family
             </div>
             <div class="form-body">
-              General Members may navigate the event calendar and purchase
-              tickets once registration is open. Anyone can sign up as a General Member at
-              any time.
+              Participating Families have early access to all events and
+              can sign up free of charge. Families who have or had a child with cancer or
+              life-threatening illness, as well as adults with cancer are eligible to apply.
+              Participating Family accounts must be reviewed and
+              approved by a Lucy's Love Bus admin.
             </div>
           </div>
           <div class="btn-row">
-            <router-link tag="button" to="sign-up-gp" class="btn--primary-orange">
+            <router-link tag="button" to="sign-up-pf" class="btn--primary-orange">
               Sign Up
             </router-link>
           </div>
@@ -30,16 +32,16 @@
         <div class="option-container auth-container">
           <div>
             <div class="form-title">
-              Participating Family
+              General Member
             </div>
             <div class="form-body">
-              Participating Families have early access to all events and
-              can sign up free of charge. Participating Family accounts must be reviewed and
-              approved by a Lucy's Love Bus admin.
+              General Members may navigate the event calendar and purchase
+              tickets once registration is open to the public.
+              Anyone can sign up as a General Member at any time.
             </div>
           </div>
           <div class="btn-row">
-            <router-link tag="button" to="sign-up-pf" class="btn--primary-orange">
+            <router-link tag="button" to="sign-up-gp" class="btn--primary-orange">
               Sign Up
             </router-link>
           </div>
@@ -70,7 +72,6 @@ export default {
     box-sizing: border-box;
     margin-top: 0;
     width: 40%;
-    height: 15rem;
 
     display: flex;
     flex-direction: column;
@@ -83,7 +84,7 @@ export default {
   .btn-row {
     display: flex;
     justify-content: flex-end;
-    align-items: flex-end;
+    margin: 10px 0 10px 0;
   }
   .submit-btn {
     box-sizing: border-box;


### PR DESCRIPTION
Super quick fixes to make the text changes to landing page and agreements form described in this ticket (https://code4community-team.monday.com/boards/677600458/pulses/723770973), and change the placement of the GM/PF sign up landing page boxes in this ticket (https://code4community-team.monday.com/boards/677600458/pulses/723769918).

Also fixed some minor styling on landing page (background orange boxes weren't covering the size of all the text if you shrunk the page horizontally, added a top margin to the sign-up button).

<img width="1244" alt="Screen Shot 2020-09-03 at 1 20 22 PM" src="https://user-images.githubusercontent.com/55663537/92146796-3bd17600-ede8-11ea-88fa-ac757983bc21.png">
