### PR TITLE
Added property to css to center 'Proceed to your profile here' text

### DIFF
--- a/src/views/SignupConfirmation.vue
+++ b/src/views/SignupConfirmation.vue
@@ -55,5 +55,6 @@ export default {
   .profile-route-text {
     margin-top: 24px;
     font-size: 1.2rem;
+    text-align: center;
   }
 </style>


### PR DESCRIPTION
Added text-align: center on the div with the "profile-route-text" class, in order to center the "Proceed to your profile text" on the Signup Confirmation page