### PR TITLE
Added validation

### DIFF
--- a/src/views/ChangePasswordlView.vue
+++ b/src/views/ChangePasswordlView.vue
@@ -90,6 +90,9 @@ export default {
       if (this.newPassword[0].length === 0) {
         newSubmitErrors[1] = 'Please enter a new password';
       }
+      if (this.currentPassword === this.newPassword[0]) {
+        newSubmitErrors[2] = 'Your new password cannot match your current password';
+      }
       if (this.newPassword[0] !== this.newPassword[1]) {
         newSubmitErrors[2] = 'Your passwords must match';
       }


### PR DESCRIPTION
Closes #139 

Added validation to ensure that the new password is not the same as the current one.

New error message
![image](https://user-images.githubusercontent.com/46979800/111391115-53889180-868a-11eb-9e04-1b26a5108544.png)
