### PR TITLE
email input type is now "email"

### DIFF
--- a/src/components/Forms/MainContactForm.vue
+++ b/src/components/Forms/MainContactForm.vue
@@ -69,7 +69,7 @@
           <input
               class="input-primary"
               :class="{ 'error-input': !!submitErrors.email }"
-              type="text"
+              type="email"
               v-bind:placeholder="value.email"
               :disabled="true">
         </label>


### PR DESCRIPTION
Closes #138.

We want to make sure the email inputs are of type "email". Luckily, there was only one that needed the change 